### PR TITLE
Fix zk:// url creation in /etc/mesos/zk

### DIFF
--- a/templates/default/zk.erb
+++ b/templates/default/zk.erb
@@ -4,4 +4,4 @@
     zk_url_list << "#{zk_server}:#{@zookeeper_port}"
   end
 %>
-<%= 'zk://' + zk_url_list.join(',') + ',/' + @zookeeper_path %>
+<%= 'zk://' + zk_url_list.join(',') + '/' + @zookeeper_path %>


### PR DESCRIPTION
The template file is generating a trailing ',' before the path in the /etc/mesos/zk file like this:

```
zk://zk1.aster.is:2181,zk2.aster.is:2181,zk3.aster.is:2181,/mesos
```

The fix just removes the trailing comma to make the output:

```
zk://zk1.aster.is:2181,zk2.aster.is:2181,zk3.aster.is:2181/mesos
```
