### PR TITLE
fixed syntax errors for chef 11.14 in master.rb and slave.rb, and distro...

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -55,7 +55,7 @@ when 'debian', 'ubuntu'
     source "#{Chef::Config[:file_cache_path]}/mesos.deb"
     not_if { ::File.exist? '/usr/local/sbin/mesos-master' }
   end
-when 'rhel', 'centos', 'amazon', 'scientific'
+when 'redhat', 'centos', 'amazon', 'scientific'
   %w( unzip libcurl ).each do |pkg|
     yum_package pkg do
       action :install
@@ -98,18 +98,18 @@ end
 # Running mesos::master recipe will reset this to 'start'
 template '/etc/init/mesos-master.conf' do
   source 'mesos-master.conf.erb'
-  variables(
-    action: 'stop',
-  )
+  variables({
+    :action => 'stop'
+  })
 end
 
 # Set init to 'stop' by default for mesos slave.
 # Running mesos::slave recipe will reset this to 'start'
 template '/etc/init/mesos-slave.conf' do
   source 'mesos-slave.conf.erb'
-  variables(
-    action: 'stop',
-  )
+  variables({
+    :action => 'stop'
+  })
 end
 
 if distro == 'debian'

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -25,18 +25,18 @@ include_recipe 'mesos::install'
 
 template '/etc/default/mesos' do
   source 'mesos.erb'
-  variables(
-    logs_dir: node['mesos']['logs_dir'],
-  )
+  variables({
+    :logs_dir => node['mesos']['logs_dir']
+  })
   notifies :run, 'bash[restart-mesos-master]', :delayed
 end
 
 template '/etc/default/mesos-master' do
   source 'mesos-master.erb'
-  variables(
-    port: node['mesos']['port'],
-    cluster_name: node['mesos']['cluster_name'],
-  )
+  variables({
+    :port => node['mesos']['port'],
+    :cluster_name => node['mesos']['cluster_name']
+  })
   notifies :run, 'bash[restart-mesos-master]', :delayed
 end
 
@@ -65,11 +65,11 @@ unless zk_server_list.nil? && zk_port.nil? && zk_path.nil?
 
   template '/etc/mesos/zk' do
     source 'zk.erb'
-    variables(
-      zookeeper_server_list: zk_server_list,
-      zookeeper_port: zk_port,
-      zookeeper_path: zk_path,
-    )
+    variables({
+      :zookeeper_server_list => zk_server_list,
+      :zookeeper_port => zk_port,
+      :zookeeper_path => zk_path
+    })
     notifies :run, 'bash[restart-mesos-master]', :delayed
   end
 end
@@ -93,9 +93,9 @@ end
 # This ensures that mesos-master is started on restart
 template '/etc/init/mesos-master.conf' do
   source 'mesos-master.conf.erb'
-  variables(
-    action: 'start',
-  )
+  variables({
+    :action => 'start'
+  })
   notifies :run, 'bash[reload-configuration]'
 end
 

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -29,18 +29,18 @@ zk_path = ''
 
 template '/etc/default/mesos' do
   source 'mesos.erb'
-  variables(
-    logs_dir: node['mesos']['logs_dir'],
-  )
+  variables({
+    :logs_dir => node['mesos']['logs_dir'],
+  })
   notifies :run, 'bash[restart-mesos-slave]', :delayed
 end
 
 template '/etc/default/mesos-slave' do
   source 'mesos-slave.erb'
-  variables(
-    work_dir: node['mesos']['work_dir'],
-    isolation_type: node['mesos']['isolation_type'],
-  )
+  variables({
+    :work_dir => node['mesos']['work_dir'],
+    :isolation_type => node['mesos']['isolation_type'],
+  })
   notifies :run, 'bash[restart-mesos-slave]', :delayed
 end
 
@@ -65,25 +65,25 @@ unless zk_server_list.count == 0 && zk_port.empty? && zk_path.empty?
 
   template '/etc/mesos/zk' do
     source 'zk.erb'
-    variables(
-      zookeeper_server_list: zk_server_list,
-      zookeeper_port: zk_port,
-      zookeeper_path: zk_path,
-    )
+    variables({
+      :zookeeper_server_list => zk_server_list,
+      :zookeeper_port => zk_port,
+      :zookeeper_path => zk_path,
+    })
     notifies :run, 'bash[restart-mesos-slave]', :delayed
   end
 end
 
 template '/usr/local/var/mesos/deploy/mesos-slave-env.sh.template' do
   source 'mesos-slave-env.sh.template.erb'
-  variables(
-    zookeeper_server_list: zk_server_list,
-    zookeeper_port: zk_port,
-    zookeeper_path: zk_path,
-    logs_dir: node['mesos']['logs_dir'],
-    work_dir: node['mesos']['work_dir'],
-    isolation_type: node['mesos']['isolation_type'],
-  )
+  variables({
+    :zookeeper_server_list => zk_server_list,
+    :zookeeper_port => zk_port,
+    :zookeeper_path => zk_path,
+    :logs_dir => node['mesos']['logs_dir'],
+    :work_dir => node['mesos']['work_dir'],
+    :isolation_type => node['mesos']['isolation_type'],
+  })
   notifies :run, 'bash[restart-mesos-slave]', :delayed
 end
 
@@ -106,9 +106,9 @@ end
 # This ensures that mesos-slave is started on restart
 template '/etc/init/mesos-slave.conf' do
   source 'mesos-slave.conf.erb'
-  variables(
-    action: 'start',
-  )
+  variables({
+    :action => 'start',
+  })
   notifies :run, 'bash[reload-configuration]'
 end
 


### PR DESCRIPTION
fixed syntax errors for chef 11.14 in master.rb and slave.rb, and fixed distro naming for 'redhat' in install.rb.
chef 11.14 did not like  
zookeeper_path: zk_path
and it  likes
:zookeeper_path => zk_path
