### PR TITLE
fixed service checks

### DIFF
--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -118,7 +118,7 @@ if node['platform'] == 'debian'
     code <<-EOH
     service mesos-master start
     EOH
-    not_if 'service mesos-master status|grep start/running'
+    not_if 'service mesos-master status|grep "start\|running"'
   end
 else
   bash 'start-mesos-master' do
@@ -126,7 +126,7 @@ else
     code <<-EOH
     start mesos-master
     EOH
-    not_if 'status mesos-master|grep start/running'
+    not_if 'status mesos-master|grep "start\|running"'
   end
 end
 
@@ -137,7 +137,7 @@ if node['platform'] == 'debian'
     code <<-EOH
     service mesos-master restart
     EOH
-    not_if 'service mesos-master status|grep stop/waiting'
+    not_if 'service mesos-master status|grep "stop\|waiting"'
   end
 else
   bash 'restart-mesos-master' do
@@ -146,6 +146,6 @@ else
     code <<-EOH
     restart mesos-master
     EOH
-    not_if 'status mesos-master|grep stop/waiting'
+    not_if 'status mesos-master|grep "stop\|waiting"'
   end
 end

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -136,7 +136,7 @@ if node['platform'] == 'debian'
     code <<-EOH
     service mesos-slave start
     EOH
-    not_if 'service mesos-slave status|grep start/running'
+    not_if 'service mesos-slave status|grep "start\|running"'
   end
 else
   bash 'start-mesos-slave' do
@@ -144,7 +144,7 @@ else
     code <<-EOH
     start mesos-slave
     EOH
-    not_if 'status mesos-slave|grep start/running'
+    not_if 'status mesos-slave|grep "start\|running"'
   end
 end
 
@@ -155,7 +155,7 @@ if node['platform'] == 'debian'
     code <<-EOH
     service mesos-slave restart
     EOH
-    not_if 'service mesos-slave status|grep stop/waiting'
+    not_if 'service mesos-slave status|grep "stop\|waiting"'
   end
 else
   bash 'restart-mesos-slave' do
@@ -164,6 +164,6 @@ else
     code <<-EOH
     restart mesos-slave
     EOH
-    not_if 'status mesos-slave|grep stop/waiting'
+    not_if 'status mesos-slave|grep "stop\|waiting"'
   end
 end


### PR DESCRIPTION
The grep commands that were used to determine if a service was running or starting didn't work, which resulted in the recipe trying to run the mesos-slave while it was already running.
