### PR TITLE
fixed missing libsvn1 dependency for debian/ubuntu

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -25,7 +25,7 @@ distro_version = node['platform_version']
 
 case distro
 when 'debian', 'ubuntu'
-  %w( unzip default-jre-headless libcurl3 ).each do |pkg|
+  %w( unzip default-jre-headless libcurl3 libsvn1).each do |pkg|
     package pkg do
       action :install
     end


### PR DESCRIPTION
When running the cookbook on a fresh system the mesos install fails because of a missing libsvn1 dependency. I added the dependency for debian/ubuntu but a similar package might be required for other distros.