### PR TITLE
Adding subversion depedency for Mesos 0.21.0+

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -67,7 +67,7 @@ when 'debian', 'ubuntu'
     not_if { ::File.exist? '/usr/local/sbin/mesos-master' }
   end
 when 'rhel', 'centos', 'amazon', 'scientific'
-  %w( unzip libcurl ).each do |pkg|
+  %w( unzip libcurl subversion ).each do |pkg|
     yum_package pkg do
       action :install
     end

--- a/test/integration/0-21-0/serverspec/mesos_install_spec.rb
+++ b/test/integration/0-21-0/serverspec/mesos_install_spec.rb
@@ -14,6 +14,7 @@ describe 'mesos install' do
       expect(package 'unzip').to be_installed
       expect(package 'libcurl').to be_installed
       expect(package 'mesos').to be_installed
+      expect(package 'subversion').to be_installed
     end
   end
 end


### PR DESCRIPTION
From Mesos 0.21.0 and greater subversions is a depedency for installing the Mesos packages.  This has already been applied to debian family installs but needs to be applied to rhel/centos as well.