### PR TITLE
Fix a bug in the zookeeper exhibitor discovery mechanism for slaves

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -19,4 +19,4 @@ end
 
 depends 'yum', '~> 3.0'
 
-recommends 'zookeeper'
+recommends 'exhibitor'

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -76,7 +76,7 @@ if node['mesos']['zookeeper_server_list'].count > 0
 end
 
 if node['mesos']['zookeeper_exhibitor_discovery'] && node['mesos']['zookeeper_exhibitor_url']
-  zk_nodes = discover_zookeepers_with_retry(node['mesos']['zookeeper_exhibitor_url'])
+  zk_nodes = MesosHelper.discover_zookeepers_with_retry(node['mesos']['zookeeper_exhibitor_url'])
 
   zk_server_list = zk_nodes['servers']
   zk_port = zk_nodes['port']


### PR DESCRIPTION
The functionality now works like the master zookeeper exhibitor 
discovery.  This pr also updates the recommended use of the
zookeeper cookbook to now recommend the use of the exhibitor cookbook
from simple finance.  This is due to the original zookeeper cookbook now 
being split between zookeeper and exhibitor cookbooks.

See:

https://github.com/SimpleFinance/chef-zookeeper
https://github.com/SimpleFinance/chef-exhibitor

Note that the discovery logic may go away altogether if we choose to punt that functionality to a user defined cookbook or logic.