### PR TITLE
Use mesosphere apt repository for package installation.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'hwilkinson@mdsol.com'
 license 'Apache 2.0'
 description 'Installs/Configures Apache Mesos'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.0.0'
+version '2.1.0'
 # rubocop:enable Style/SingleSpaceBeforeFirstArg
 
 %w( ubuntu debian centos amazon scientific ).each do |os|

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'hwilkinson@mdsol.com'
 license 'Apache 2.0'
 description 'Installs/Configures Apache Mesos'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.1.0'
+version '2.0.0'
 # rubocop:enable Style/SingleSpaceBeforeFirstArg
 
 %w( ubuntu debian centos amazon scientific ).each do |os|

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -55,7 +55,7 @@ when 'debian', 'ubuntu'
     end
   end
 
-  apt_repository "mesosphere" do
+  apt_repository 'mesosphere' do
     uri "http://repos.mesosphere.io/#{node['platform']}"
     distribution node['lsb']['codename']
     keyserver 'keyserver.ubuntu.com'
@@ -63,10 +63,10 @@ when 'debian', 'ubuntu'
     components ['main']
   end
 
-  package "mesos" do
+  package 'mesos' do
     action :install
     # --no-install-recommends to skip installing zk. unnecessary.
-    options "--no-install-recommends"
+    options '--no-install-recommends'
     # Glob is necessary to select the deb version string
     version "#{node['mesos']['version']}*"
   end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -55,16 +55,20 @@ when 'debian', 'ubuntu'
     end
   end
 
-  remote_file "#{Chef::Config[:file_cache_path]}/mesos.deb" do
-    source package_url
-    checksum package_checksum
-    action :create
-    not_if { ::File.exist? '/usr/local/sbin/mesos-master' }
+  apt_repository "mesosphere" do
+    uri "http://repos.mesosphere.io/#{node['platform']}"
+    distribution node['lsb']['codename']
+    keyserver 'keyserver.ubuntu.com'
+    key 'E56151BF'
+    components ['main']
   end
 
-  dpkg_package 'mesos' do
-    source "#{Chef::Config[:file_cache_path]}/mesos.deb"
-    not_if { ::File.exist? '/usr/local/sbin/mesos-master' }
+  package "mesos" do
+    action :install
+    # --no-install-recommends to skip installing zk. unnecessary.
+    options "--no-install-recommends"
+    # Glob is necessary to select the deb version string
+    version "#{node['mesos']['version']}*"
   end
 when 'rhel', 'centos', 'amazon', 'scientific'
   %w( unzip libcurl subversion ).each do |pkg|


### PR DESCRIPTION
Instead of using remote_file and dpkg -i to install the package, add
Mesosphere's Debian repository and apt-get install from there.

This removes the dependency on mdsol/mesos_cookbook's
attributes file when used as a wrapper cookbook and allows for
updating the version of mesos as soon as it's published to the repo

Tests already exist in mesos_install_spec.rb for package
installation.