### PR TITLE
Removed logic that set machine hostname based on EC2 public dns name.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,7 +3,7 @@ source 'https://supermarket.getchef.com'
 metadata
 
 cookbook 'yum', '~> 3.0'
-cookbook 'exhibitor', git: 'git@github.com:SimpleFinance/chef-exhibitor.git'
+cookbook 'exhibitor', git: 'git@github.com:SimpleFinance/chef-exhibitor.git', branch: 'master'
 
 group :integration do
   cookbook 'zookeeper-apt',  path: 'test/cookbooks/zookeeper-apt'

--- a/Berksfile
+++ b/Berksfile
@@ -3,6 +3,7 @@ source 'https://supermarket.getchef.com'
 metadata
 
 cookbook 'yum', '~> 3.0'
+cookbook 'exhibitor', git: 'git@github.com:SimpleFinance/chef-exhibitor.git'
 
 group :integration do
   cookbook 'zookeeper-apt',  path: 'test/cookbooks/zookeeper-apt'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -98,10 +98,6 @@ default['mesos']['zookeeper_exhibitor_discovery']           = false
 # Netflix Exhibitor ZooKeeper ensemble url.
 default['mesos']['zookeeper_exhibitor_url']                 = nil
 
-# Setting this option to true will update mesos node hostnames to their public
-# EC2 hostname.
-default['mesos']['set_ec2_hostname']                        = true
-
 case node['platform_family']
 when 'rhel'
   default['java']['jdk_version'] = '7'

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,4 +19,4 @@ end
 
 depends 'yum', '~> 3.0'
 
-recommends 'exhibitor'
+recommends 'exhibitor', '0.4.0'

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -97,21 +97,6 @@ unless zk_server_list.nil? && zk_port.nil? && zk_path.nil?
   end
 end
 
-# If we are on ec2 set the public dns as the hostname so that
-# mesos master redirection works properly.
-if node.attribute?('ec2') && node['mesos']['set_ec2_hostname']
-  bash 'set-aws-public-hostname' do
-    user 'root'
-    code <<-EOH
-      PUBLIC_DNS=`wget -q -O - http://instance-data.ec2.internal/latest/meta-data/public-hostname`
-      hostname $PUBLIC_DNS
-      echo $PUBLIC_DNS > /etc/hostname
-      HOSTNAME=$PUBLIC_DNS  # Fix the bash built-in hostname variable too
-    EOH
-    not_if 'hostname | grep amazonaws.com'
-  end
-end
-
 # Set init to 'start' by default for mesos master.
 # This ensures that mesos-master is started on restart
 template '/etc/init/mesos-master.conf' do

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -117,21 +117,6 @@ template '/usr/local/var/mesos/deploy/mesos-slave-env.sh.template' do
   notifies :run, 'bash[restart-mesos-slave]', :delayed
 end
 
-# If we are on ec2 set the public dns as the hostname so that
-# mesos slave reports work properly in the UI.
-if node.attribute?('ec2') && node['mesos']['set_ec2_hostname']
-  bash 'set-aws-public-hostname' do
-    user 'root'
-    code <<-EOH
-      PUBLIC_DNS=`wget -q -O - http://instance-data.ec2.internal/latest/meta-data/public-hostname`
-      hostname $PUBLIC_DNS
-      echo $PUBLIC_DNS > /etc/hostname
-      HOSTNAME=$PUBLIC_DNS  # Fix the bash built-in hostname variable too
-    EOH
-    not_if 'hostname | grep amazonaws.com'
-  end
-end
-
 # Set init to 'start' by default for mesos slave.
 # This ensures that mesos-slave is started on restart
 template '/etc/init/mesos-slave.conf' do


### PR DESCRIPTION
This was legacy code that was needed when running Mesos in EC2 prior to
Mesos having the --hostname option.  Also added Exhibitor in the
Berksfile which replaces Zookeeper and is needed for exhibitor based
zookeeper discovery.