### PR TITLE
Add switch for default cookbook repository

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,12 +1,14 @@
-# Mesosphere Mesos version.  The version configured here must exist in
-# attributes/mesosphere_packages.rb.
-default['mesos']['version']                                 = '0.21.1'
+# Enable default repo
+default['mesos']['repo']    = true
+
+# Mesosphere Mesos version.
+default['mesos']['version'] = '0.21.1'
 
 # Init system to use
-default['mesos']['init'] = case node['platform']
-                           when 'debian' then 'sysvinit_debian'
-                           else 'upstart'
-                           end
+default['mesos']['init']    = case node['platform']
+                              when 'debian' then 'sysvinit_debian'
+                              else 'upstart'
+                              end
 
 #
 # Mesos MASTER configuration

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -29,12 +29,5 @@ module MesosHelper
     Chef::Log.warn("Error while attempting to discover exhibitor zookeepers: Retry #{6 - tries} of 5")
     retry unless (tries -= 1).zero?
   end
-
-  def self.mesos_rpm_version_release(mesos_version)
-    cmd = Mixlib::ShellOut.new("repoquery --queryformat '%{VERSION}-%{RELEASE}' -q mesos-#{mesos_version}*")
-    cmd.run_command
-    cmd.error!
-    cmd.stdout.strip
-  end
 end
 # rubocop:eable Style/ClassAndModuleChildren

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -76,8 +76,14 @@ when 'rhel', 'redhat', 'centos', 'amazon', 'scientific'
     mode 0644
   end
 
+  # get the version-release string via repoquery
+  cmd = Mixlib::ShellOut.new("repoquery --queryformat '%{VERSION}-%{RELEASE}' -q mesos-#{node['mesos']['version']}*")
+  cmd.run_command
+  cmd.error!
+  rpm_version = cmd.stdout.strip
+
   yum_package 'mesos' do
-    version MesosHelper.mesos_rpm_version_release(node['mesos']['version'])
+    version rpm_version
     not_if { ::File.exist? '/usr/local/sbin/mesos-master' }
   end
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -20,14 +20,17 @@
 include_recipe 'chef-sugar'
 include_recipe 'java::default'
 
-distro = node['platform']
+#
+# Install default repos
+#
 
-directory '/etc/mesos-chef'
+include_recipe 'mesos::repo' if node['mesos']['repo']
 
-# Configure package repositories
-include_recipe 'mesos::repo'
+#
+# Install package
+#
 
-case distro
+case node['platform']
 when 'debian', 'ubuntu'
   %w( unzip default-jre-headless libcurl3 libsvn1).each do |pkg|
     package pkg do
@@ -82,6 +85,8 @@ end
 #
 # Support for multiple init systems
 #
+
+directory '/etc/mesos-chef'
 
 # Init templates
 template 'mesos-master-init' do

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -20,10 +20,7 @@
 include_recipe 'apt' if debian?
 include_recipe 'yum' if rhel?
 
-distro = node['platform']
-distro_version = node['platform_version']
-
-case distro
+case node['platform']
 when 'debian', 'ubuntu'
   # Add mesosphere deb repository
   apt_repository 'mesosphere' do
@@ -35,29 +32,21 @@ when 'debian', 'ubuntu'
   end
 when 'rhel', 'redhat', 'centos', 'amazon', 'scientific'
   # Add mesosphere RPM repository
-  if distro_version.start_with?('6')
-    compile_time do
-      remote_file "#{Chef::Config[:file_cache_path]}/mesosphere-el-repo-6-2.noarch.rpm" do
-        source 'http://repos.mesosphere.io/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm'
-        action :create
-      end
-
-      rpm_package 'mesosphere-el-repo-6-2' do
-        source "#{Chef::Config[:file_cache_path]}/mesosphere-el-repo-6-2.noarch.rpm"
-        action :install
-      end
-    end
-  elsif distro_version.start_with?('7')
-    compile_time do
-      remote_file "#{Chef::Config[:file_cache_path]}/mesosphere-el-repo-7-1.noarch.rpm" do
+  compile_time do
+    remote_file 'mesos-rpm-yum' do
+      case node['platform_version'].split('.').first
+      when '7'
         source 'http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm'
-        action :create
+      when '6'
+        source 'http://repos.mesosphere.io/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm'
       end
+      path "#{Chef::Config[:file_cache_path]}/mesosphere-el-repo.noarch.rpm"
+      action :create
+    end
 
-      rpm_package 'mesosphere-el-repo-7-1' do
-        source "#{Chef::Config[:file_cache_path]}/mesosphere-el-repo-7-1.noarch.rpm"
-        action :install
-      end
+    rpm_package 'mesos-rpm-yum' do
+      source "#{Chef::Config[:file_cache_path]}/mesosphere-el-repo.noarch.rpm"
+      action :install
     end
   end
 end


### PR DESCRIPTION
If someone would like to mirror the mesosphere repository on their own infrastructure, or have their own packages, one should be able to disable the default mesosphere repository.