### PR TITLE
Changed 'compile_time do' to 'at_compile_time do' per error message from...

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -46,7 +46,7 @@ when 'debian', 'ubuntu'
     version "#{node['mesos']['version']}*"
   end
 when 'rhel', 'redhat', 'centos', 'amazon', 'scientific'
-  compile_time do
+  at_compile_time do
     package 'yum-utils'
   end
 

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -32,7 +32,7 @@ when 'debian', 'ubuntu'
   end
 when 'rhel', 'redhat', 'centos', 'amazon', 'scientific'
   # Add mesosphere RPM repository
-  compile_time do
+  at_compile_time do
     remote_file 'mesos-rpm-yum' do
       case node['platform_version'].split('.').first
       when '7'


### PR DESCRIPTION
[Chef-sugar](https://github.com/sethvargo/chef-sugar) no longer offers compile_time as a filter. To successfully run the mesos::master recipe I needed to change the few instances of compile_time to at_compile_time.
