### PR TITLE
Add vagrant-wrapper in Gemfile for tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'chef', '~> 11.12.2'
 group :integration do
   gem 'rake'
   gem 'test-kitchen'
+  gem 'vagrant-wrapper'
   gem 'kitchen-vagrant'
   gem 'kitchen-docker'
   gem 'kitchen-ec2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,7 @@ GEM
     treetop (1.5.3)
       polyglot (~> 0.3)
     uuidtools (2.1.4)
+    vagrant-wrapper (2.0.2)
     varia_model (0.3.2)
       buff-extensions (~> 0.2)
       hashie (>= 2.0.2)
@@ -299,3 +300,4 @@ DEPENDENCIES
   rubocop (~> 0.28)
   serverspec
   test-kitchen
+  vagrant-wrapper


### PR DESCRIPTION
vagrant-wrapper is a simple wrapper that allow developers to have the
vagrant gem installed