### PR TITLE
make syslog optional

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,9 @@ end
 # Ulimit to pass to mesos-master process.
 default['mesos']['master']['env']['ULIMIT']                 = '-n 16384'
 
+# Send stdout & stderr to syslog
+default['mesos']['master']['syslog']                        = true
+
 # mesos-master default port
 default['mesos']['master']['flags']['port']                 = 5050
 
@@ -52,6 +55,9 @@ end
 
 # Ulimit to pass to mesos-slave process.
 default['mesos']['slave']['env']['ULIMIT']                  = '-n 16384'
+
+# Send stdout & stderr to syslog
+default['mesos']['slave']['syslog']                        = true
 
 # mesos-slave default port
 default['mesos']['slave']['flags']['port']                  = 5051

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -56,9 +56,10 @@ template 'mesos-master-wrapper' do
   group 'root'
   mode '0755'
   source 'wrapper.erb'
-  variables(env:   node['mesos']['master']['env'],
-            bin:   node['mesos']['master']['bin'],
-            flags: node['mesos']['master']['flags'])
+  variables(env:    node['mesos']['master']['env'],
+            bin:    node['mesos']['master']['bin'],
+            flags:  node['mesos']['master']['flags'],
+            syslog: node['mesos']['master']['syslog'])
 end
 
 # Mesos master service definition

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -56,9 +56,10 @@ template 'mesos-slave-wrapper' do
   group 'root'
   mode '0755'
   source 'wrapper.erb'
-  variables(env:   node['mesos']['slave']['env'],
-            bin:   node['mesos']['slave']['bin'],
-            flags: node['mesos']['slave']['flags'])
+  variables(env:    node['mesos']['slave']['env'],
+            bin:    node['mesos']['slave']['bin'],
+            flags:  node['mesos']['slave']['flags'],
+            syslog: node['mesos']['slave']['syslog'])
 end
 
 # Mesos master service definition

--- a/templates/default/wrapper.erb
+++ b/templates/default/wrapper.erb
@@ -7,9 +7,11 @@
 # set ulimit if defined
 [[ ! ${ULIMIT:-} ]] || ulimit $ULIMIT
 
+<%- if @syslog -%>
 # stdout and stderr to syslog
 exec 1> >(exec logger -p user.info -t "<%= ::File.basename(@bin) %>")
 exec 2> >(exec logger -p user.err  -t "<%= ::File.basename(@bin) %>")
+<%- end -%>
 
 # mesos binary configuration
 exec <%= @bin %> \

--- a/test/integration/default/serverspec/mesos_master_spec.rb
+++ b/test/integration/default/serverspec/mesos_master_spec.rb
@@ -31,3 +31,8 @@ describe command('curl -sD - http://localhost:5050/state.json') do
   its(:stdout) { should match(/"authenticate_slaves":"false"/) }
   its(:stdout) { should match(/"activated_slaves":\s*1/) }
 end
+
+describe file('/etc/mesos-chef/mesos-master') do
+  its(:content) { should contain 'exec 1> >\\(exec logger -p user.info -t "mesos-master"\\)' }
+  its(:content) { should contain 'exec 2> >\\(exec logger -p user.err  -t "mesos-master"\\)' }
+end

--- a/test/integration/default/serverspec/mesos_slave_spec.rb
+++ b/test/integration/default/serverspec/mesos_slave_spec.rb
@@ -31,3 +31,8 @@ describe command('curl -sD - http://localhost:5051/state.json') do
   its(:stdout) { should match(/"checkpoint":"true"/) }
   its(:stdout) { should match(/"switch_user":"true"/) }
 end
+
+describe file('/etc/mesos-chef/mesos-slave') do
+  its(:content) { should contain 'exec 1> >\\(exec logger -p user.info -t "mesos-slave"\\)' }
+  its(:content) { should contain 'exec 2> >\\(exec logger -p user.err  -t "mesos-slave"\\)' }
+end


### PR DESCRIPTION
currently logs are going to /var/log/syslog & /var/log/mesos/. This makes syslog optional.