### PR TITLE
Improved upstart script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+- Improved upstart script to start after network
+
 ## [3.4.0] - 2015-08-25
 ### Added
 - Added support for Apache Mesos 0.23.0.

--- a/templates/default/upstart.erb
+++ b/templates/default/upstart.erb
@@ -1,6 +1,6 @@
 description "Upstart job for <%= @name %>"
 
-start on runlevel [2345]
+start on stopped rc RUNLEVEL=[2345]
 respawn
 
 exec <%= @wrapper %>


### PR DESCRIPTION
After a server reboot, mesos could start before network is up.
If the server has local ips such as 127.0.1.1, mesos processes will
adversise an ipaddress 127.0.1.1 to slaves (or master) which lead to
chaos in the cluster.

http://serverfault.com/a/370869/98600 suggests to use a better start
condition to ensure that mesos processes are started on correct runlevel
(after network is up).
Related documentation for this is on
http://upstart.ubuntu.com/cookbook/#really-understanding-start-on-and-stop-on