### PR TITLE
Remove compile time and chef-sugar dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+- Remove dependency on chef-sugar
 - Set up yum repo with `yum_repository` provider
 - Fix Amazon Linux support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+- Set up yum repo with `yum_repository` provider
 - Fix Amazon Linux support
 
 ## [3.5.0] - 2015-12-21

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ version '3.5.0'
 end
 
 # Cookbook dependencies
-%w( java apt chef-sugar ).each do |cb|
+%w( java apt ).each do |cb|
   depends cb
 end
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -17,8 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'chef-sugar'
-include_recipe 'java::default'
+include_recipe 'java'
 
 #
 # Install default repos
@@ -30,8 +29,8 @@ include_recipe 'mesos::repo' if node['mesos']['repo']
 # Install package
 #
 
-case node['platform']
-when 'debian', 'ubuntu'
+case node['platform_family']
+when 'debian'
   %w( unzip default-jre-headless libcurl3 libsvn1).each do |pkg|
     package pkg do
       action :install
@@ -45,7 +44,7 @@ when 'debian', 'ubuntu'
     # Glob is necessary to select the deb version string
     version "#{node['mesos']['version']}*"
   end
-when 'rhel', 'redhat', 'centos', 'amazon', 'scientific'
+when 'rhel'
   %w( unzip libcurl subversion ).each do |pkg|
     yum_package pkg do
       action :install

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -52,16 +52,14 @@ when 'rhel', 'redhat', 'centos', 'amazon', 'scientific'
     end
   end
 
-  # refresh Yum cache before querying
-  Chef::Provider::Package::Yum::YumCache.instance.refresh
-  # get the version-release string directly from the Yum provider rpmdb
-  rpm_version = Chef::Provider::Package::Yum::YumCache.instance
-                .instance_variable_get('@rpmdb').lookup('mesos')
-                .find { |pkg| pkg.version.v == node['mesos']['version'] }
-                .version.to_s
-
   yum_package 'mesos' do
-    version rpm_version
+    version lazy {
+      # get the version-release string directly from the Yum provider rpmdb
+      Chef::Provider::Package::Yum::YumCache.instance
+        .instance_variable_get('@rpmdb').lookup('mesos')
+        .find { |pkg| pkg.version.v == node['mesos']['version'] }
+        .version.to_s
+    }
     not_if { ::File.exist? '/usr/local/sbin/mesos-master' }
   end
 end

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -17,12 +17,10 @@
 # limitations under the License.
 #
 
-include_recipe 'apt' if debian?
-include_recipe 'yum' if rhel?
+case node['platform_family']
+when 'debian'
+  include_recipe 'apt'
 
-case node['platform']
-when 'debian', 'ubuntu'
-  # Add mesosphere deb repository
   apt_repository 'mesosphere' do
     uri "http://repos.mesosphere.io/#{node['platform']}"
     distribution node['lsb']['codename']
@@ -30,8 +28,9 @@ when 'debian', 'ubuntu'
     key 'E56151BF'
     components ['main']
   end
-when 'redhat', 'centos', 'scientific', 'amazon'
-  # Add mesosphere RPM repository
+when 'rhel'
+  include_recipe 'yum'
+
   version = case node['platform']
             when 'amazon' then '6'
             else node['platform_version'].split('.').first

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -32,25 +32,13 @@ when 'debian', 'ubuntu'
   end
 when 'redhat', 'centos', 'scientific', 'amazon'
   # Add mesosphere RPM repository
-  at_compile_time do
-    remote_file 'mesos-rpm-yum' do
-      if node['platform'] == 'amazon'
-        source 'http://repos.mesosphere.io/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm'
-      else
-        case node['platform_version'].split('.').first
-        when '7'
-          source 'http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm'
-        when '6'
-          source 'http://repos.mesosphere.io/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm'
-        end
-      end
-      path "#{Chef::Config[:file_cache_path]}/mesosphere-el-repo.noarch.rpm"
-      action :create
-    end
-
-    rpm_package 'mesos-rpm-yum' do
-      source "#{Chef::Config[:file_cache_path]}/mesosphere-el-repo.noarch.rpm"
-      action :install
-    end
+  version = case node['platform']
+            when 'amazon' then '6'
+            else node['platform_version'].split('.').first
+            end
+  yum_repository 'mesosphere' do
+    description 'Mesosphere Packages for Enteprise Linux'
+    baseurl "http://repos.mesosphere.io/el/#{version}/$basearch/"
+    gpgkey 'https://repos.mesosphere.io/el/RPM-GPG-KEY-mesosphere'
   end
 end


### PR DESCRIPTION
This should standardise the way repositories are configured across all distributions. In addition, chef-sugar is not needed anymore. Solves #87.