### PR TITLE
Adding quotes in wrapper template to flags that are passed in as strings.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,6 +37,11 @@ platforms:
 suites:
 - &default
   name: 0-25-0
+  attributes:
+    mesos:
+      slave:
+        flags:
+          attributes: 'attribute01:value01;attribute02:value02'
   run_list:
     - recipe[mesos::master]
     - recipe[mesos::slave]

--- a/templates/default/wrapper.erb
+++ b/templates/default/wrapper.erb
@@ -19,7 +19,9 @@ exec <%= @bin %> \
 <%-   case value                                                           -%>
 <%-   when Hash                                                            -%>
   <%=   "--#{flag}='"%><%= value.map{|k,v| "#{k}:#{v}"}.join(';') %><%= "'" %> \
-<%-   when String, Integer                                                 -%>
+<%-   when String                                                          -%>
+  <%=   "--#{flag}='#{value}'"                                             %> \
+<%-   when Integer                                                         -%>
   <%=   "--#{flag}=#{value}"                                                %> \
 <%-   else                                                                 -%>
   <%=   "--#{value ? '' : 'no-'}#{flag}"                                    %> \


### PR DESCRIPTION
This fixes an issue with passing in mesos attributes that
contain semi-colons as separators which causes mesos slave processes to
falil to start up because the shell thinks the semi-colons are end
statements.  Added example attribute string to default 0.25.0 suite.