### PR TITLE
add support for oracle 6.7 and oracle 7.2 platforms

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,6 +33,12 @@ platforms:
   - name: centos-6.7
     run_list:
       - recipe[yum]
+  - name: box-cutter/ol67
+    run_list:
+      - recipe[yum]
+  - name: box-cutter/ol72
+    run_list:
+      - recipe[yum]
 
 suites:
 - &default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,7 +13,7 @@ default['mesos']['init']       = case node['platform']
                                    node['platform_version'].to_i >= 8 ? 'systemd' : 'sysvinit_debian'
                                  when 'ubuntu'
                                    node['platform_version'].to_f >= 15.04 ? 'systemd' : 'upstart'
-                                 when 'redhat', 'centos', 'scientific' # ~FC024
+                                 when 'redhat', 'centos', 'scientific', 'oracle' # ~FC024
                                    node['platform_version'].to_i >= 7 ? 'systemd' : 'upstart'
                                  else 'upstart'
                                  end

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '3.5.1'
 # rubocop:enable Style/SingleSpaceBeforeFirstArg
 
-%w( ubuntu debian centos amazon scientific ).each do |os|
+%w( ubuntu debian centos amazon scientific oracle ).each do |os|
   supports os
 end
 


### PR DESCRIPTION

Support new  OEL (Oracle Enterprise Linux) Platforms:
1. oracle-6.7-x86_64
2. oracle-7.2-x86_64

I ran test kitchen against the following vagrant boxes:
Built via https://github.com/chef/bento 
bin/bento build --only=virtualbox-iso oracle-6.7-x86_64
bin/bento build --only=virtualbox-iso oracle-7.2-x86_64
and 
box-cutter/ol67
box-cutter/ol72

All tests passed using either bento vagrant boxes (6.7/7.2) via bento build, or box-cutter (6.7/7.2).

I left the .kitchen.yml using box-cutter/ol67 and box-cutter/ol72 vagrant boxes for the tests as they are immediately available via hashicorp.