### PR TITLE
Mesos agent 1.0.0 --help doesn't work without work_dir

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,4 +37,4 @@ RSpec::Core::RakeTask.new(:spec)
 desc 'Run all tests on Travis'
 task travis: %w(style)
 
-task default: %w( style integration:vagrant )
+task default: %w(style integration:vagrant)

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,12 +7,12 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '3.5.1'
 # rubocop:enable Style/SingleSpaceBeforeFirstArg
 
-%w( ubuntu debian centos amazon scientific oracle ).each do |os|
+%w(ubuntu debian centos amazon scientific oracle).each do |os|
   supports os
 end
 
 # Cookbook dependencies
-%w( java apt ).each do |cb|
+%w(java apt).each do |cb|
   depends cb
 end
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -31,7 +31,7 @@ include_recipe 'mesos::repo' if node['mesos']['repo']
 
 case node['platform_family']
 when 'debian'
-  %w( unzip default-jre-headless libcurl3 libsvn1).each do |pkg|
+  %w(unzip default-jre-headless libcurl3 libsvn1).each do |pkg|
     package pkg do
       action :install
     end
@@ -45,7 +45,7 @@ when 'debian'
     version "#{node['mesos']['version']}*"
   end
 when 'rhel'
-  %w( unzip libcurl subversion ).each do |pkg|
+  %w(unzip libcurl subversion).each do |pkg|
     yum_package pkg do
       action :install
     end
@@ -75,7 +75,7 @@ template 'mesos-master-init' do
     path '/etc/systemd/system/mesos-master.service'
     source 'systemd.erb'
   when 'sysvinit_debian'
-    mode 0755
+    mode 0o755
     path '/etc/init.d/mesos-master'
     source 'sysvinit_debian.erb'
   when 'upstart'
@@ -92,7 +92,7 @@ template 'mesos-slave-init' do
     path '/etc/systemd/system/mesos-slave.service'
     source 'systemd.erb'
   when 'sysvinit_debian'
-    mode 0755
+    mode 0o755
     path '/etc/init.d/mesos-slave'
     source 'sysvinit_debian.erb'
   when 'upstart'

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -27,7 +27,7 @@ include_recipe 'mesos::install'
 ruby_block 'mesos-slave-configuration-validation' do
   block do
     # Get Mesos --help
-    help = Mixlib::ShellOut.new("#{node['mesos']['slave']['bin']} --help")
+    help = Mixlib::ShellOut.new("#{node['mesos']['slave']['bin']} --help --work_dir=#{node['mesos']['slave']['flags']['work_dir']}")
     help.run_command
     help.error!
     # Extract options


### PR DESCRIPTION
work_dir has been enforced as a mandatory argument of `mesos-agent`.
Consequently, even when doing `mesos-agent --help`, it returns an exit_status of 1.

Here we set the work_dir, another approach would have been to not check that the exit_status is in error.

See https://issues.apache.org/jira/browse/MESOS-5922 for more context.