### PR TITLE
Fix: IP address attribute

### DIFF
--- a/.kitchen.ec2.yml
+++ b/.kitchen.ec2.yml
@@ -90,8 +90,8 @@ suites:
   - &default
     name: 1-1-0
     run_list:
-      - recipe[mesos::master]
-      - recipe[mesos::slave]
+      - recipe[mesos_v2::master]
+      - recipe[mesos_v2::slave]
     attributes:
       mesos:
         slave:

--- a/.kitchen.ec2.yml
+++ b/.kitchen.ec2.yml
@@ -90,8 +90,8 @@ suites:
   - &default
     name: 1-1-0
     run_list:
-      - recipe[mesos_v2::master]
-      - recipe[mesos_v2::slave]
+      - recipe[mesos_pkg::master]
+      - recipe[mesos_pkg::slave]
     attributes:
       mesos:
         slave:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,7 +37,7 @@ suites:
     name: mesos-master
     run_list:
       - recipe[zookeeper::default]
-      - recipe[mesos_v2::master]
+      - recipe[mesos_pkg::master]
     attributes:
       mesos:
         version: *version
@@ -50,7 +50,7 @@ suites:
   -
     name: mesos-slave
     run_list:
-      - recipe[mesos_v2::slave]
+      - recipe[mesos_pkg::slave]
     attributes:
       mesos:
         version: *version

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -47,3 +47,6 @@ suites:
   - <<: *default
     name: 1-0-0
     attributes: {mesos: {version: '1.0.0'}}
+  - <<: *default
+    name: 0-24-2
+    attributes: {mesos: {version: '0.24.2'}}

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,7 +30,7 @@ platforms:
 # - name: box-cutter/ol72
 #   run_list: ['recipe[yum]']
 
-version: &version 0.24.2
+version: &version 1.1.0
 
 suites:
   -

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,23 +30,29 @@ platforms:
 # - name: box-cutter/ol72
 #   run_list: ['recipe[yum]']
 
+version: &version 0.24.2
+
 suites:
-  - &default
-    name: 1-1-0
+  -
+    name: mesos-master
     run_list:
       - recipe[mesos::master]
+    attributes:
+      mesos:
+        version: *version
+    driver:
+      network:
+        - ["private_network", {ip: "192.168.33.33"}]
+  -
+    name: mesos-slave
+    run_list:
       - recipe[mesos::slave]
     attributes:
       mesos:
+        version: *version
         slave:
           flags:
-            attributes: 'attribute01:value01;attribute02:value02'
-  - <<: *default
-    name: 1-0-1
-    attributes: {mesos: {version: '1.0.1'}}
-  - <<: *default
-    name: 1-0-0
-    attributes: {mesos: {version: '1.0.0'}}
-  - <<: *default
-    name: 0-24-2
-    attributes: {mesos: {version: '0.24.2'}}
+            zk: 192.168.33.33:2181
+    driver:
+      network:
+        - ["private_network", {ip: "192.168.33.34"}]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,13 +36,17 @@ suites:
   -
     name: mesos-master
     run_list:
+      - recipe[zookeeper::default]
       - recipe[mesos::master]
     attributes:
       mesos:
         version: *version
+        master:
+          flags:
+            ip: &ip 192.168.33.33
     driver:
       network:
-        - ["private_network", {ip: "192.168.33.33"}]
+        - ["private_network", {ip: *ip}]
   -
     name: mesos-slave
     run_list:
@@ -52,7 +56,8 @@ suites:
         version: *version
         slave:
           flags:
-            zk: 192.168.33.33:2181
+            ip: &ip 192.168.33.34
+            master: zk://192.168.33.33:2181/mesos
     driver:
       network:
-        - ["private_network", {ip: "192.168.33.34"}]
+        - ["private_network", {ip: *ip}]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,7 +37,7 @@ suites:
     name: mesos-master
     run_list:
       - recipe[zookeeper::default]
-      - recipe[mesos::master]
+      - recipe[mesos_v2::master]
     attributes:
       mesos:
         version: *version
@@ -50,7 +50,7 @@ suites:
   -
     name: mesos-slave
     run_list:
-      - recipe[mesos::slave]
+      - recipe[mesos_v2::slave]
     attributes:
       mesos:
         version: *version

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,7 +17,7 @@ platforms:
     run_list: ['recipe[apt]', 'recipe[curl]']
   - name: ubuntu-12.04
     run_list: ['recipe[apt]', 'recipe[curl]']
-  - name: debian-8.6
+  - name: debian/jessie64
     run_list: ['recipe[apt]']
     attributes: {java: {jdk_version: '7'}}
   - name: centos-7.2

--- a/Berksfile
+++ b/Berksfile
@@ -4,3 +4,4 @@ metadata
 
 cookbook 'curl'
 cookbook 'exhibitor', git: 'git@github.com:SimpleFinance/chef-exhibitor.git', branch: 'master'
+cookbook "dnsdiscovery", git: "git@github.com:duedil-ltd/chef-dnsdiscovery.git"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ https://github.com/apache/mesos/blob/master/docs/configuration.md
 ## Recipes
 
 ### default
-The default mesos recipe will run mesos::install.
+The default mesos recipe will run mesos_v2::install.
 
 ### install
 The install recipe installs the specified version of the mesosphere mesos
@@ -70,14 +70,14 @@ mesos-master and mesos-slave init files so that they don't automatically
 start on server restart.
 
 ### master
-The master recipe runs mesos::install as well as creating several
+The master recipe runs mesos_v2::install as well as creating several
 mesos-master configuration files that are used at startup.  This recipe also
 uses the zookeeper attributes and/or exhibitor attributes to configure the
 mesos-master using zookeeper.  Lastly it sets the mesos-master init config to
 'start' so that mesos-master is started on server restart.
 
 ### slave
-The slave recipe runs mesos::install as well as creating several
+The slave recipe runs mesos_v2::install as well as creating several
 mesos-slave configuration files that are used at startup.  This recipe also
 uses the zookeeper attributes and/or exhibitor attributes to configure the
 mesos-slave using zookeeper.  Lastly it sets the mesos-slave init config to
@@ -121,7 +121,7 @@ override_attributes:
         cluster: 'mesos-sandbox'
         zk: 'zk://127.0.0.1:2181/mesos'
 run_list:
-  recipe[mesos::master]
+  recipe[mesos_v2::master]
 ```
 
 Here is a sample role for creating a Mesos slave node with a seperate ZooKeeper
@@ -140,7 +140,7 @@ override_attributes:
       flags:
         master: 'zk://127.0.0.1:2181/mesos'
 run_list:
-  recipe[mesos::slave]
+  recipe[mesos_v2::slave]
 ```
 
 Development
@@ -154,15 +154,15 @@ License and Author
 
 Copyright 2015 Medidata Solutions Worldwide
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
-this file except in compliance with the License. You may obtain a copy of the 
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
 License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software distributed 
-under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 
 [Apache Mesos]: http://mesos.apache.org

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ https://github.com/apache/mesos/blob/master/docs/configuration.md
 ## Recipes
 
 ### default
-The default mesos recipe will run mesos_v2::install.
+The default mesos recipe will run mesos_pkg::install.
 
 ### install
 The install recipe installs the specified version of the mesosphere mesos
@@ -70,14 +70,14 @@ mesos-master and mesos-slave init files so that they don't automatically
 start on server restart.
 
 ### master
-The master recipe runs mesos_v2::install as well as creating several
+The master recipe runs mesos_pkg::install as well as creating several
 mesos-master configuration files that are used at startup.  This recipe also
 uses the zookeeper attributes and/or exhibitor attributes to configure the
 mesos-master using zookeeper.  Lastly it sets the mesos-master init config to
 'start' so that mesos-master is started on server restart.
 
 ### slave
-The slave recipe runs mesos_v2::install as well as creating several
+The slave recipe runs mesos_pkg::install as well as creating several
 mesos-slave configuration files that are used at startup.  This recipe also
 uses the zookeeper attributes and/or exhibitor attributes to configure the
 mesos-slave using zookeeper.  Lastly it sets the mesos-slave init config to
@@ -121,7 +121,7 @@ override_attributes:
         cluster: 'mesos-sandbox'
         zk: 'zk://127.0.0.1:2181/mesos'
 run_list:
-  recipe[mesos_v2::master]
+  recipe[mesos_pkg::master]
 ```
 
 Here is a sample role for creating a Mesos slave node with a seperate ZooKeeper
@@ -140,7 +140,7 @@ override_attributes:
       flags:
         master: 'zk://127.0.0.1:2181/mesos'
 run_list:
-  recipe[mesos_v2::slave]
+  recipe[mesos_pkg::slave]
 ```
 
 Development

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,9 @@ sudo add-apt-repository \
    stable"
 sudo apt-get update
 sudo apt-get install -y docker-ce
+sed -i 's_fd://_fd:// --insecure-registry registry.docker.duedil.net_' /lib/systemd/system/docker.service
+sudo systemctl daemon-reload
+sudo systemctl restart docker.service
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.box = 'debian/contrib-jessie64'
-  config.vm.synced_folder "/Users/dmilanp/DueDil/Repos", "/duedil"
+  # config.vm.synced_folder "/path/to/duedil", "/duedil"
 
   config.vm.network :forwarded_port, guest: 80, host: 8080
   config.vm.network :forwarded_port, guest: 443, host: 4443

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,90 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = '2'
+Vagrant.require_version '>= 1.5.0'
+
+$script = <<SCRIPT
+# Install docker
+sudo apt-get install -y\
+     apt-transport-https \
+     ca-certificates \
+     curl \
+     gnupg2 \
+     software-properties-common
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
+sudo apt-key fingerprint 0EBFCD88
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/debian \
+   $(lsb_release -cs) \
+   stable"
+sudo apt-get update
+sudo apt-get install -y docker-ce
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  if Vagrant.has_plugin?("vagrant-omnibus")
+    config.omnibus.chef_version = 'latest'
+  end
+
+  config.vm.box = 'debian/contrib-jessie64'
+  config.vm.synced_folder "/Users/dmilanp/DueDil/Repos", "/duedil"
+
+  config.vm.network :forwarded_port, guest: 80, host: 8080
+  config.vm.network :forwarded_port, guest: 443, host: 4443
+
+  # First machine
+  config.vm.define "first", primary: true do |first|
+    first.vm.network "private_network", ip: "192.168.33.33"
+    first.vm.hostname = "mesos"
+  end
+
+  # Second machine
+  # config.vm.define "second" do |second|
+  #   second.network "private_network", ip: "192.168.33.34"
+  # end
+
+  # Berkshelf
+  config.berkshelf.enabled = true
+
+  # Configure memory and cpus
+  config.vm.provider :virtualbox do |vb|
+    vb.memory = 2048
+    vb.cpus = 2
+  end
+
+  config.vm.provision :chef_solo do |chef|
+
+    # Provide json
+    chef.json = {
+      'java' => {'jdk_version' => '7'},
+      'mesos' =>{
+        'version' => '1.1.0',
+        'master' => {
+          'flags' => {
+            'ip' => '192.168.33.33'
+          }
+        },
+        'slave' => {
+          'flags' => {
+            'ip' => '192.168.33.33',
+            'master' => 'zk://192.168.33.33:2181/mesos'
+          }
+        }
+      }
+
+    }
+
+    # Provide run list
+    chef.run_list = [
+        'recipe[zookeeper::default]',
+        'recipe[mesos_v2::master]',
+        'recipe[mesos_v2::slave]',
+    ]
+
+  end
+
+  config.vm.provision "shell", inline: $script
+
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,8 +82,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Provide run list
     chef.run_list = [
         'recipe[zookeeper::default]',
-        'recipe[mesos_v2::master]',
-        'recipe[mesos_v2::slave]',
+        'recipe[mesos_pkg::master]',
+        'recipe[mesos_pkg::slave]',
     ]
 
   end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,10 +34,10 @@ default['mesos']['master']['syslog']                = true
 # Mesos master command line flags.
 # http://mesos.apache.org/documentation/latest/configuration/
 default['mesos']['master']['flags']['port']          = 5050
-default['mesos']['master']['flags']['log_dir']       = '/var/log/mesos'
+default['mesos']['master']['flags']['log_dir']       = '/var/log/mesos-' + node['mesos']['version'].gsub(/\./, '-')
 default['mesos']['master']['flags']['logging_level'] = 'INFO'
 default['mesos']['master']['flags']['cluster']       = 'MyMesosCluster'
-default['mesos']['master']['flags']['work_dir']      = '/var/lib/mesos-master'
+default['mesos']['master']['flags']['work_dir']      = '/var/lib/mesos-master-' + node['mesos']['version'].gsub(/\./, '-')
 default['mesos']['master']['flags']['zk']            = 'zk://127.0.0.1:2181/mesos'
 default['mesos']['master']['flags']['quorum']        = 1
 default['mesos']['master']['flags']['ip']            = node[:ip]
@@ -58,9 +58,9 @@ default['mesos']['slave']['syslog']                 = true
 # Mesos slave command line flags
 # http://mesos.apache.org/documentation/latest/configuration/
 default['mesos']['slave']['flags']['port']          = 5051
-default['mesos']['slave']['flags']['log_dir']       = '/var/log/mesos'
+default['mesos']['slave']['flags']['log_dir']       = '/var/log/mesos-' + node['mesos']['version'].gsub(/\./, '-')
 default['mesos']['slave']['flags']['logging_level'] = 'INFO'
-default['mesos']['slave']['flags']['work_dir']      = '/var/lib/mesos-slave'
+default['mesos']['slave']['flags']['work_dir']      = '/var/lib/mesos-slave-' + node['mesos']['version'].gsub(/\./, '-')
 default['mesos']['slave']['flags']['isolation']     = 'posix/cpu,posix/mem'
 default['mesos']['slave']['flags']['master']        = 'zk://127.0.0.1:2181/mesos'
 default['mesos']['slave']['flags']['strict']        = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,7 +37,7 @@ default['mesos']['master']['flags']['port']          = 5050
 default['mesos']['master']['flags']['log_dir']       = '/var/log/mesos'
 default['mesos']['master']['flags']['logging_level'] = 'INFO'
 default['mesos']['master']['flags']['cluster']       = 'MyMesosCluster'
-default['mesos']['master']['flags']['work_dir']      = '/tmp/mesos'
+default['mesos']['master']['flags']['work_dir']      = '/var/lib/mesos-master'
 
 #
 # Mesos SLAVE configuration
@@ -57,7 +57,7 @@ default['mesos']['slave']['syslog']                 = true
 default['mesos']['slave']['flags']['port']          = 5051
 default['mesos']['slave']['flags']['log_dir']       = '/var/log/mesos'
 default['mesos']['slave']['flags']['logging_level'] = 'INFO'
-default['mesos']['slave']['flags']['work_dir']      = '/tmp/mesos'
+default['mesos']['slave']['flags']['work_dir']      = '/var/lib/mesos-slave'
 default['mesos']['slave']['flags']['isolation']     = 'posix/cpu,posix/mem'
 default['mesos']['slave']['flags']['master']        = 'localhost:5050'
 default['mesos']['slave']['flags']['strict']        = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -79,5 +79,18 @@ default['mesos']['zookeeper_path']                      = 'mesos'
 # Flag to enable Zookeeper ensemble discovery via Netflix Exhibitor.
 default['mesos']['zookeeper_exhibitor_discovery']       = false
 
+# Flag to enable Zookeeper ensemble discovery via Duedil DNSDiscovery.
+default['mesos']['zookeeper_duedil_dns_discovery']         = false
+
+default['mesos']['duedil_dns_discovery']['cluster_name'] = nil, # Required for discovery to work
+default['mesos']['duedil_dns_discovery']['web_ui_service_name'] = "http",
+default['mesos']['duedil_dns_discovery']['master_service_name'] = "mesos-master",
+default['mesos']['duedil_dns_discovery']['slave_service_name'] = "mesos-slave",
+default['mesos']['duedil_dns_discovery']['zk']['domain'] = node[:domain],
+default['mesos']['duedil_dns_discovery']['zk']['cluster_name'] = nil, # Required for ZK discovery to work
+default['mesos']['duedil_dns_discovery']['zk']['service_name'] = "zookeeper-client",
+default['mesos']['duedil_dns_discovery']['zk']['path'] = "/mesos"
+
+
 # Netflix Exhibitor ZooKeeper ensemble url.
 default['mesos']['zookeeper_exhibitor_url']             = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,7 +65,7 @@ default['mesos']['slave']['flags']['isolation']     = 'posix/cpu,posix/mem'
 default['mesos']['slave']['flags']['master']        = 'zk://127.0.0.1:2181/mesos'
 default['mesos']['slave']['flags']['strict']        = true
 default['mesos']['slave']['flags']['recover']       = 'reconnect'
-default['mesos']['slave']['flags']['ip']            = node[:ip]
+default['mesos']['slave']['flags']['ip']            = node[:ipaddress]
 
 # Workaround for setting default cgroups hierarchy root
 default['mesos']['slave']['flags']['cgroups_hierarchy'] = if node['mesos']['init'] == 'systemd'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -89,7 +89,6 @@ default['mesos']['duedil_dns_discovery']['slave_service_name'] = "mesos-slave",
 default['mesos']['duedil_dns_discovery']['zk']['domain'] = node[:domain],
 default['mesos']['duedil_dns_discovery']['zk']['cluster_name'] = nil, # Required for ZK discovery to work
 default['mesos']['duedil_dns_discovery']['zk']['service_name'] = "zookeeper-client",
-default['mesos']['duedil_dns_discovery']['zk']['path'] = "/mesos"
 
 
 # Netflix Exhibitor ZooKeeper ensemble url.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,6 +38,7 @@ default['mesos']['master']['flags']['log_dir']       = '/var/log/mesos'
 default['mesos']['master']['flags']['logging_level'] = 'INFO'
 default['mesos']['master']['flags']['cluster']       = 'MyMesosCluster'
 default['mesos']['master']['flags']['work_dir']      = '/var/lib/mesos-master'
+default['mesos']['master']['flags']['zk']            = 'zk://127.0.0.1:2181/mesos'
 
 #
 # Mesos SLAVE configuration
@@ -59,7 +60,7 @@ default['mesos']['slave']['flags']['log_dir']       = '/var/log/mesos'
 default['mesos']['slave']['flags']['logging_level'] = 'INFO'
 default['mesos']['slave']['flags']['work_dir']      = '/var/lib/mesos-slave'
 default['mesos']['slave']['flags']['isolation']     = 'posix/cpu,posix/mem'
-default['mesos']['slave']['flags']['master']        = 'localhost:5050'
+default['mesos']['slave']['flags']['master']        = 'zk://127.0.0.1:2181/mesos'
 default['mesos']['slave']['flags']['strict']        = true
 default['mesos']['slave']['flags']['recover']       = 'reconnect'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,6 +39,8 @@ default['mesos']['master']['flags']['logging_level'] = 'INFO'
 default['mesos']['master']['flags']['cluster']       = 'MyMesosCluster'
 default['mesos']['master']['flags']['work_dir']      = '/var/lib/mesos-master'
 default['mesos']['master']['flags']['zk']            = 'zk://127.0.0.1:2181/mesos'
+default['mesos']['master']['flags']['quorum']        = 1
+default['mesos']['master']['flags']['ip']            = node[:ip]
 
 #
 # Mesos SLAVE configuration
@@ -63,6 +65,7 @@ default['mesos']['slave']['flags']['isolation']     = 'posix/cpu,posix/mem'
 default['mesos']['slave']['flags']['master']        = 'zk://127.0.0.1:2181/mesos'
 default['mesos']['slave']['flags']['strict']        = true
 default['mesos']['slave']['flags']['recover']       = 'reconnect'
+default['mesos']['slave']['flags']['ip']            = node[:ip]
 
 # Workaround for setting default cgroups hierarchy root
 default['mesos']['slave']['flags']['cgroups_hierarchy'] = if node['mesos']['init'] == 'systemd'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,6 +12,6 @@ issues_url       'https://github.com/mdsol/mesos_cookbook/issues'
   supports os
 end
 
-%w(java apt yum).each do |cookbook|
+%w(java apt yum dnsdiscovery).each do |cookbook|
   depends cookbook
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,4 @@
-name             'mesos'
+name             'mesos_v2'
 maintainer       'Ray Rodriguez'
 maintainer_email 'rayrod2030@gmail.com'
 license          'Apache 2.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,12 +1,12 @@
 name             'mesos_v2'
-maintainer       'Ray Rodriguez'
-maintainer_email 'rayrod2030@gmail.com'
+maintainer       'DueDil Infrastructure team'
+maintainer_email 'infra@duedil.com'
 license          'Apache 2.0'
 description      'Installs/Configures Apache Mesos'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '3.6.0'
-source_url       'https://github.com/mdsol/mesos_cookbook'
-issues_url       'https://github.com/mdsol/mesos_cookbook/issues'
+source_url       'https://github.com/duedil-ltd/mesos_cookbook'
+issues_url       'https://github.com/duedil-ltd/mesos_cookbook/issues'
 
 %w(ubuntu debian centos amazon scientific oracle).each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,4 @@
-name             'mesos_v2'
+name             'mesos_pkg'
 maintainer       'DueDil Infrastructure team'
 maintainer_email 'infra@duedil.com'
 license          'Apache 2.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'infra@duedil.com'
 license          'Apache 2.0'
 description      'Installs/Configures Apache Mesos'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.6.0'
+version          '3.6.1'
 source_url       'https://github.com/duedil-ltd/mesos_cookbook'
 issues_url       'https://github.com/duedil-ltd/mesos_cookbook/issues'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,4 +18,4 @@
 #
 
 # install mesos package
-include_recipe 'mesos_v2::install'
+include_recipe 'mesos_pkg::install'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,4 +18,4 @@
 #
 
 # install mesos package
-include_recipe 'mesos::install'
+include_recipe 'mesos_v2::install'

--- a/recipes/discovery_zk.rb
+++ b/recipes/discovery_zk.rb
@@ -19,7 +19,7 @@ end
 # Create the ZK string attribute
 zk_string = "zk://"
 zk_string << hostnames.sort.join(",")
-zk_string << "/" + node[:mesos][:duedil_dns_discovery][:zk][:path].gsub(/^\//, "")
+zk_string << "/" + node['mesos']['zookeeper_path']
 
 # Set the relevant attributes
 node.override['mesos']['master']['flags']['zk'] = zk_string

--- a/recipes/discovery_zk.rb
+++ b/recipes/discovery_zk.rb
@@ -1,0 +1,27 @@
+
+# Grab the cluster name we want to use
+zk_cluster_name = node[:mesos][:duedil_dns_discovery][:zk][:cluster_name]
+raise "A zk:cluster_name is required for auto discovery" if zk_cluster_name.nil?
+
+# Figure out which domain to look for zookeeper in
+zk_domain = node[:mesos][:duedil_dns_discovery][:zk][:domain] || node[:domain]
+
+# Discover the zookeeper nodes
+zk_instances = DNSDiscovery::Helper.discover_instances("zookeeper-client", zk_domain, :subtype => zk_cluster_name)
+raise "No zookeeper instances could be discovered" if zk_instances.nil? || zk_instances.size == 0
+
+# Build the list
+hostnames = []
+zk_instances.each do |instance|
+    hostnames << "#{instance.target}:#{instance.port}"
+end
+
+# Create the ZK string attribute
+zk_string = "zk://"
+zk_string << hostnames.sort.join(",")
+zk_string << "/" + node[:mesos][:duedil_dns_discovery][:zk][:path].gsub(/^\//, "")
+
+# Set the relevant attributes
+node.override['mesos']['master']['flags']['zk'] = zk_string
+node.override['mesos']['slave']['flags']['master'] = zk_string
+

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -23,7 +23,7 @@ include_recipe 'java'
 # Install default repos
 #
 
-include_recipe 'mesos_v2::repo' if node['mesos']['repo']
+include_recipe 'mesos_pkg::repo' if node['mesos']['repo']
 
 #
 # Install package
@@ -124,7 +124,7 @@ service 'mesos-master-default' do
     provider Chef::Provider::Service::Upstart
   end
   action [:stop, :disable]
-  not_if { node['recipes'].include?('mesos_v2::master') }
+  not_if { node['recipes'].include?('mesos_pkg::master') }
 end
 
 service 'mesos-slave-default' do
@@ -138,5 +138,5 @@ service 'mesos-slave-default' do
     provider Chef::Provider::Service::Upstart
   end
   action [:stop, :disable]
-  not_if { node['recipes'].include?('mesos_v2::slave') }
+  not_if { node['recipes'].include?('mesos_pkg::slave') }
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -23,7 +23,7 @@ include_recipe 'java'
 # Install default repos
 #
 
-include_recipe 'mesos::repo' if node['mesos']['repo']
+include_recipe 'mesos_v2::repo' if node['mesos']['repo']
 
 #
 # Install package
@@ -124,7 +124,7 @@ service 'mesos-master-default' do
     provider Chef::Provider::Service::Upstart
   end
   action [:stop, :disable]
-  not_if { node['recipes'].include?('mesos::master') }
+  not_if { node['recipes'].include?('mesos_v2::master') }
 end
 
 service 'mesos-slave-default' do
@@ -138,5 +138,5 @@ service 'mesos-slave-default' do
     provider Chef::Provider::Service::Upstart
   end
   action [:stop, :disable]
-  not_if { node['recipes'].include?('mesos::slave') }
+  not_if { node['recipes'].include?('mesos_v2::slave') }
 end

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -23,7 +23,7 @@ end
 
 directory node['mesos']['master']['flags']['work_dir']
 
-include_recipe 'mesos_v2::install'
+include_recipe 'mesos_pkg::install'
 
 # Mesos configuration validation
 ruby_block 'mesos-master-configuration-validation' do
@@ -55,7 +55,7 @@ if node['mesos']['zookeeper_exhibitor_discovery'] && node['mesos']['zookeeper_ex
   node.override['mesos']['master']['flags']['zk'] = 'zk://' + zk_nodes['servers'].sort.map { |s| "#{s}:#{zk_nodes['port']}" }.join(',') + '/' + node['mesos']['zookeeper_path']
 elsif node['mesos']['zookeeper_duedil_dns_discovery'] && node['mesos']['duedil_dns_discovery']
   # Duedil DNSDiscovery
-  include_recipe "mesos_v2::discovery_zk"
+  include_recipe "mesos_pkg::discovery_zk"
 end
 
 # Mesos master configuration wrapper

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -41,8 +41,9 @@ ruby_block 'mesos-master-configuration-validation' do
   end
 end
 
-# ZooKeeper Exhibitor discovery
+# ZooKeeper discovery
 if node['mesos']['zookeeper_exhibitor_discovery'] && node['mesos']['zookeeper_exhibitor_url']
+  # Exhibitor
   zk_nodes = MesosHelper.discover_zookeepers_with_retry(node['mesos']['zookeeper_exhibitor_url'])
 
   if zk_nodes.nil?
@@ -50,7 +51,8 @@ if node['mesos']['zookeeper_exhibitor_discovery'] && node['mesos']['zookeeper_ex
   end
 
   node.override['mesos']['master']['flags']['zk'] = 'zk://' + zk_nodes['servers'].sort.map { |s| "#{s}:#{zk_nodes['port']}" }.join(',') + '/' + node['mesos']['zookeeper_path']
-elsif node['mesos']['zookeeper_duedil_dns_discovery'] && node['mesos']['discovery']
+elsif node['mesos']['zookeeper_duedil_dns_discovery'] && node['mesos']['duedil_dns_discovery']
+  # Duedil DNSDiscovery
   include_recipe "mesos::discovery_zk"
 end
 

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -21,7 +21,7 @@ class Chef::Recipe
   include MesosHelper
 end
 
-include_recipe 'mesos::install'
+include_recipe 'mesos_v2::install'
 
 # Mesos configuration validation
 ruby_block 'mesos-master-configuration-validation' do
@@ -53,7 +53,7 @@ if node['mesos']['zookeeper_exhibitor_discovery'] && node['mesos']['zookeeper_ex
   node.override['mesos']['master']['flags']['zk'] = 'zk://' + zk_nodes['servers'].sort.map { |s| "#{s}:#{zk_nodes['port']}" }.join(',') + '/' + node['mesos']['zookeeper_path']
 elsif node['mesos']['zookeeper_duedil_dns_discovery'] && node['mesos']['duedil_dns_discovery']
   # Duedil DNSDiscovery
-  include_recipe "mesos::discovery_zk"
+  include_recipe "mesos_v2::discovery_zk"
 end
 
 # Mesos master configuration wrapper

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -50,6 +50,8 @@ if node['mesos']['zookeeper_exhibitor_discovery'] && node['mesos']['zookeeper_ex
   end
 
   node.override['mesos']['master']['flags']['zk'] = 'zk://' + zk_nodes['servers'].sort.map { |s| "#{s}:#{zk_nodes['port']}" }.join(',') + '/' + node['mesos']['zookeeper_path']
+elsif node['mesos']['zookeeper_duedil_dns_discovery'] && node['mesos']['discovery']
+  include_recipe "mesos::discovery_zk"
 end
 
 # Mesos master configuration wrapper

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -21,6 +21,8 @@ class Chef::Recipe
   include MesosHelper
 end
 
+directory node['mesos']['master']['flags']['work_dir']
+
 include_recipe 'mesos_v2::install'
 
 # Mesos configuration validation

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -21,6 +21,8 @@ class Chef::Recipe
   include MesosHelper
 end
 
+directory node['mesos']['slave']['flags']['work_dir']
+
 include_recipe 'mesos_v2::install'
 
 # Mesos configuration validation

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -23,7 +23,7 @@ end
 
 directory node['mesos']['slave']['flags']['work_dir']
 
-include_recipe 'mesos_v2::install'
+include_recipe 'mesos_pkg::install'
 
 # Mesos configuration validation
 ruby_block 'mesos-slave-configuration-validation' do
@@ -50,7 +50,7 @@ if node['mesos']['zookeeper_exhibitor_discovery'] && node['mesos']['zookeeper_ex
   node.override['mesos']['slave']['flags']['master'] = 'zk://' + zk_nodes['servers'].map { |s| "#{s}:#{zk_nodes['port']}" }.join(',') + '/' + node['mesos']['zookeeper_path']
 elsif node['mesos']['zookeeper_duedil_dns_discovery'] && node['mesos']['duedil_dns_discovery']
   # Duedil DNSDiscovery
-  include_recipe "mesos_v2::discovery_zk"
+  include_recipe "mesos_pkg::discovery_zk"
 end
 
 # this directory doesn't exist on newer versions of Mesos, i.e. 0.21.0+

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -21,7 +21,7 @@ class Chef::Recipe
   include MesosHelper
 end
 
-include_recipe 'mesos::install'
+include_recipe 'mesos_v2::install'
 
 # Mesos configuration validation
 ruby_block 'mesos-slave-configuration-validation' do
@@ -48,7 +48,7 @@ if node['mesos']['zookeeper_exhibitor_discovery'] && node['mesos']['zookeeper_ex
   node.override['mesos']['slave']['flags']['master'] = 'zk://' + zk_nodes['servers'].map { |s| "#{s}:#{zk_nodes['port']}" }.join(',') + '/' + node['mesos']['zookeeper_path']
 elsif node['mesos']['zookeeper_duedil_dns_discovery'] && node['mesos']['duedil_dns_discovery']
   # Duedil DNSDiscovery
-  include_recipe "mesos::discovery_zk"
+  include_recipe "mesos_v2::discovery_zk"
 end
 
 # this directory doesn't exist on newer versions of Mesos, i.e. 0.21.0+

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -41,10 +41,14 @@ ruby_block 'mesos-slave-configuration-validation' do
   end
 end
 
-# ZooKeeper Exhibitor discovery
+# ZooKeeper discovery
 if node['mesos']['zookeeper_exhibitor_discovery'] && node['mesos']['zookeeper_exhibitor_url']
+  # Exhibitor
   zk_nodes = MesosHelper.discover_zookeepers_with_retry(node['mesos']['zookeeper_exhibitor_url'])
   node.override['mesos']['slave']['flags']['master'] = 'zk://' + zk_nodes['servers'].map { |s| "#{s}:#{zk_nodes['port']}" }.join(',') + '/' + node['mesos']['zookeeper_path']
+elsif node['mesos']['zookeeper_duedil_dns_discovery'] && node['mesos']['duedil_dns_discovery']
+  # Duedil DNSDiscovery
+  include_recipe "mesos::discovery_zk"
 end
 
 # this directory doesn't exist on newer versions of Mesos, i.e. 0.21.0+

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -5,14 +5,14 @@
 
 require 'spec_helper'
 
-describe 'mesos_v2::default' do
+describe 'mesos_pkg::default' do
   context 'It should include recipe install' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '7.1.1503')
       runner.converge(described_recipe)
     end
-    it 'includes mesos_v2::install recipe' do
-      expect(chef_run).to include_recipe('mesos_v2::install')
+    it 'includes mesos_pkg::install recipe' do
+      expect(chef_run).to include_recipe('mesos_pkg::install')
     end
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -5,14 +5,14 @@
 
 require 'spec_helper'
 
-describe 'mesos::default' do
+describe 'mesos_v2::default' do
   context 'It should include recipe install' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '7.1.1503')
       runner.converge(described_recipe)
     end
-    it 'includes mesos::install recipe' do
-      expect(chef_run).to include_recipe('mesos::install')
+    it 'includes mesos_v2::install recipe' do
+      expect(chef_run).to include_recipe('mesos_v2::install')
     end
   end
 end

--- a/spec/unit/recipes/install_spec.rb
+++ b/spec/unit/recipes/install_spec.rb
@@ -5,7 +5,7 @@
 
 require 'spec_helper'
 
-describe 'mesos::install' do
+describe 'mesos_v2::install' do
   context 'When all attributes are default, on CentOS 7' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '7.1.1503')
@@ -14,8 +14,8 @@ describe 'mesos::install' do
     it 'Includes recipe Java' do
       expect(chef_run).to include_recipe('java')
     end
-    it 'Includes recipe mesos::repo' do
-      expect(chef_run).to include_recipe('mesos::repo')
+    it 'Includes recipe mesos_v2::repo' do
+      expect(chef_run).to include_recipe('mesos_v2::repo')
     end
     it 'Installs util packages' do
       expect(chef_run).to install_yum_package('unzip')

--- a/spec/unit/recipes/install_spec.rb
+++ b/spec/unit/recipes/install_spec.rb
@@ -5,7 +5,7 @@
 
 require 'spec_helper'
 
-describe 'mesos_v2::install' do
+describe 'mesos_pkg::install' do
   context 'When all attributes are default, on CentOS 7' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '7.1.1503')
@@ -14,8 +14,8 @@ describe 'mesos_v2::install' do
     it 'Includes recipe Java' do
       expect(chef_run).to include_recipe('java')
     end
-    it 'Includes recipe mesos_v2::repo' do
-      expect(chef_run).to include_recipe('mesos_v2::repo')
+    it 'Includes recipe mesos_pkg::repo' do
+      expect(chef_run).to include_recipe('mesos_pkg::repo')
     end
     it 'Installs util packages' do
       expect(chef_run).to install_yum_package('unzip')

--- a/spec/unit/recipes/master_spec.rb
+++ b/spec/unit/recipes/master_spec.rb
@@ -5,14 +5,14 @@
 
 require 'spec_helper'
 
-describe 'mesos_v2::master' do
+describe 'mesos_pkg::master' do
   context 'When all attributes are default, on CentOS 7' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '7.1.1503')
       runner.converge(described_recipe)
     end
-    it 'Includes recipe mesos_v2::install' do
-      expect(chef_run).to include_recipe('mesos_v2::install')
+    it 'Includes recipe mesos_pkg::install' do
+      expect(chef_run).to include_recipe('mesos_pkg::install')
     end
     it 'Includes renders template for start script' do
       expect(chef_run).to create_template('/etc/mesos-chef/mesos-master').with(

--- a/spec/unit/recipes/master_spec.rb
+++ b/spec/unit/recipes/master_spec.rb
@@ -5,14 +5,14 @@
 
 require 'spec_helper'
 
-describe 'mesos::master' do
+describe 'mesos_v2::master' do
   context 'When all attributes are default, on CentOS 7' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '7.1.1503')
       runner.converge(described_recipe)
     end
-    it 'Includes recipe mesos::install' do
-      expect(chef_run).to include_recipe('mesos::install')
+    it 'Includes recipe mesos_v2::install' do
+      expect(chef_run).to include_recipe('mesos_v2::install')
     end
     it 'Includes renders template for start script' do
       expect(chef_run).to create_template('/etc/mesos-chef/mesos-master').with(

--- a/spec/unit/recipes/repo_spec.rb
+++ b/spec/unit/recipes/repo_spec.rb
@@ -5,7 +5,7 @@
 
 require 'spec_helper'
 
-describe 'mesos::install' do
+describe 'mesos_v2::install' do
   context 'When all attributes are default, on CentOS 7' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '7.1.1503')

--- a/spec/unit/recipes/repo_spec.rb
+++ b/spec/unit/recipes/repo_spec.rb
@@ -5,7 +5,7 @@
 
 require 'spec_helper'
 
-describe 'mesos_v2::install' do
+describe 'mesos_pkg::install' do
   context 'When all attributes are default, on CentOS 7' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '7.1.1503')

--- a/spec/unit/recipes/slave_spec.rb
+++ b/spec/unit/recipes/slave_spec.rb
@@ -5,14 +5,14 @@
 
 require 'spec_helper'
 
-describe 'mesos_v2::slave' do
+describe 'mesos_pkg::slave' do
   context 'When all attributes are default, on CentOS 7' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '7.1.1503')
       runner.converge(described_recipe)
     end
-    it 'Includes recipe mesos_v2::install' do
-      expect(chef_run).to include_recipe('mesos_v2::install')
+    it 'Includes recipe mesos_pkg::install' do
+      expect(chef_run).to include_recipe('mesos_pkg::install')
     end
     it 'Creates deploy directory' do
       expect(chef_run).to create_directory('/usr/local/var/mesos/deploy/')

--- a/spec/unit/recipes/slave_spec.rb
+++ b/spec/unit/recipes/slave_spec.rb
@@ -5,14 +5,14 @@
 
 require 'spec_helper'
 
-describe 'mesos::slave' do
+describe 'mesos_v2::slave' do
   context 'When all attributes are default, on CentOS 7' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '7.1.1503')
       runner.converge(described_recipe)
     end
-    it 'Includes recipe mesos::install' do
-      expect(chef_run).to include_recipe('mesos::install')
+    it 'Includes recipe mesos_v2::install' do
+      expect(chef_run).to include_recipe('mesos_v2::install')
     end
     it 'Creates deploy directory' do
       expect(chef_run).to create_directory('/usr/local/var/mesos/deploy/')

--- a/templates/default/slave_cleanup.sh.erb
+++ b/templates/default/slave_cleanup.sh.erb
@@ -1,0 +1,4 @@
+# Managed by Chef!
+# See slave.rb recipe in mesos cookbook for more information about this script
+
+cd <%= @work_dir %> && ls slaves/ | head -n-1 | xargs -t -I{} rm -r slaves/{}


### PR DESCRIPTION
:node["ip"] doesn't seem to work (we get `no-ip` in the host), and our old cookbook uses :node["ipaddress"] for this (which is also the attribute listed in the Chef docs).