### PR TITLE
Improve package management

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 ---
 AllCops:
+  TargetRubyVersion: "2.3"
   Exclude:
     - vendor/**/*
     - bin/**/*

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://supermarket.getchef.com'
 
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'berkshelf'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'rubocop/rake_task'
 require 'foodcritic'
@@ -35,6 +37,6 @@ end
 RSpec::Core::RakeTask.new(:spec)
 
 desc 'Run all tests on Travis'
-task travis: %w(style)
+task travis: %w[style]
 
-task default: %w(style integration:vagrant)
+task default: %w[style integration:vagrant]

--- a/Thorfile
+++ b/Thorfile
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'bundler'
 require 'bundler/setup'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,7 +7,12 @@ default['mesos']['repo']       = true
 # Mesosphere Mesos version.
 default['mesos']['version']    = '1.1.0'
 
-default['mesos']['package_options'] = ['--no-install-recommends']
+default['mesos']['package_options'] = case node['platform_family']
+                                      when 'debian'
+                                        ['--no-install-recommends']
+                                      when 'rhel'
+                                        []
+                                      end
 
 # Init system to use
 default['mesos']['init']       = case node['platform']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,6 +7,8 @@ default['mesos']['repo']       = true
 # Mesosphere Mesos version.
 default['mesos']['version']    = '1.1.0'
 
+default['mesos']['package_options'] = ['--no-install-recommends']
+
 # Init system to use
 default['mesos']['init']       = case node['platform']
                                  when 'debian'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Default Java version
 default['java']['jdk_version'] = '8'
 
@@ -15,15 +17,15 @@ default['mesos']['package_options'] = case node['platform_family']
                                       end
 
 # Init system to use
-default['mesos']['init']       = case node['platform']
-                                 when 'debian'
-                                   node['platform_version'].to_i >= 8 ? 'systemd' : 'sysvinit_debian'
-                                 when 'ubuntu'
-                                   node['platform_version'].to_f >= 15.04 ? 'systemd' : 'upstart'
-                                 when 'redhat', 'centos', 'scientific', 'oracle' # ~FC024
-                                   node['platform_version'].to_i >= 7 ? 'systemd' : 'upstart'
-                                 else 'upstart'
-                                 end
+default['mesos']['init'] = case node['platform']
+                           when 'debian'
+                             node['platform_version'].to_i >= 8 ? 'systemd' : 'sysvinit_debian'
+                           when 'ubuntu'
+                             node['platform_version'].to_f >= 15.04 ? 'systemd' : 'upstart'
+                           when 'redhat', 'centos', 'scientific', 'oracle' # ~FC024
+                             node['platform_version'].to_i >= 7 ? 'systemd' : 'upstart'
+                           else 'upstart'
+                           end
 
 #
 # Mesos MASTER configuration

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook Name:: mesos
 # Library:: helpers

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 name             'mesos'
 maintainer       'Ray Rodriguez'
 maintainer_email 'rayrod2030@gmail.com'
@@ -8,11 +10,11 @@ version          '3.6.0'
 source_url       'https://github.com/mdsol/mesos_cookbook'
 issues_url       'https://github.com/mdsol/mesos_cookbook/issues'
 
-%w(ubuntu debian centos amazon scientific oracle).each do |os|
+%w[ubuntu debian centos amazon scientific oracle].each do |os|
   supports os
 end
 
-%w(java apt yum).each do |cookbook|
+%w[java apt yum].each do |cookbook|
   depends cookbook
 end
 chef_version '>= 11' if respond_to?(:chef_version)

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name             'mesos'
 maintainer       'Ray Rodriguez'
 maintainer_email 'rayrod2030@gmail.com'
-license          'Apache 2.0'
+license          'Apache-2.0'
 description      'Installs/Configures Apache Mesos'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '3.6.0'
@@ -15,3 +15,4 @@ end
 %w(java apt yum).each do |cookbook|
   depends cookbook
 end
+chef_version '>= 11' if respond_to?(:chef_version)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook Name:: mesos
 # Recipe:: default

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -52,13 +52,7 @@ when 'rhel'
   end
 
   yum_package 'mesos' do
-    version lazy {
-      # get the version-release string directly from the Yum provider rpmdb
-      Chef::Provider::Package::Yum::YumCache
-        .instance.instance_variable_get('@rpmdb').lookup('mesos')
-        .find { |pkg| pkg.version.v == node['mesos']['version'] }
-        .version.to_s
-    }
+    version node['mesos']['version']
   end
 end
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook Name:: mesos
 # Recipe:: install
@@ -31,7 +33,7 @@ include_recipe 'mesos::repo' if node['mesos']['repo']
 
 case node['platform_family']
 when 'debian'
-  %w(unzip default-jre-headless libcurl3 libsvn1).each do |pkg|
+  %w[unzip default-jre-headless libcurl3 libsvn1].each do |pkg|
     package pkg do
       action :install
     end
@@ -45,7 +47,7 @@ when 'debian'
     version "#{node['mesos']['version']}*"
   end
 when 'rhel'
-  %w(unzip libcurl subversion).each do |pkg|
+  %w[unzip libcurl subversion].each do |pkg|
     yum_package pkg do
       action :install
     end
@@ -118,7 +120,7 @@ service 'mesos-master-default' do
   when 'upstart'
     provider Chef::Provider::Service::Upstart
   end
-  action [:stop, :disable]
+  action %i[stop disable]
   not_if { node['recipes'].include?('mesos::master') }
 end
 
@@ -132,6 +134,6 @@ service 'mesos-slave-default' do
   when 'upstart'
     provider Chef::Provider::Service::Upstart
   end
-  action [:stop, :disable]
+  action %i[stop disable]
   not_if { node['recipes'].include?('mesos::slave') }
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -40,7 +40,7 @@ when 'debian'
   package 'mesos' do
     action :install
     # --no-install-recommends to skip installing zk. unnecessary.
-    options node['mesos']['package_options']
+    options node['mesos']['package_options'].join(' ')
     # Glob is necessary to select the deb version string
     version "#{node['mesos']['version']}*"
   end
@@ -53,6 +53,7 @@ when 'rhel'
 
   yum_package 'mesos' do
     version node['mesos']['version']
+    options node['mesos']['package_options'].join(' ')
   end
 end
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -40,7 +40,7 @@ when 'debian'
   package 'mesos' do
     action :install
     # --no-install-recommends to skip installing zk. unnecessary.
-    options '--no-install-recommends'
+    options node['mesos']['package_options']
     # Glob is necessary to select the deb version string
     version "#{node['mesos']['version']}*"
   end

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook Name:: mesos
 # Recipe:: master
@@ -78,5 +80,5 @@ service 'mesos-master' do
   supports status: true, restart: true
   subscribes :restart, 'template[mesos-master-init]'
   subscribes :restart, 'template[mesos-master-wrapper]'
-  action [:enable, :start]
+  action %i[enable start]
 end

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook Name:: mesos
 # Recipe:: repo

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook Name:: mesos
 # Recipe:: slave
@@ -78,5 +80,5 @@ service 'mesos-slave' do
   supports status: true, restart: true
   subscribes :restart, 'template[mesos-slave-init]'
   subscribes :restart, 'template[mesos-slave-wrapper]'
-  action [:enable, :start]
+  action %i[enable start]
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'chefspec'
 require 'chefspec/berkshelf'
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook Name:: mesos
 # Spec:: default

--- a/spec/unit/recipes/install_spec.rb
+++ b/spec/unit/recipes/install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook Name:: mesos
 # Spec:: install

--- a/spec/unit/recipes/master_spec.rb
+++ b/spec/unit/recipes/master_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook Name:: mesos
 # Spec:: master

--- a/spec/unit/recipes/repo_spec.rb
+++ b/spec/unit/recipes/repo_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook Name:: mesos
 # Spec:: repo

--- a/spec/unit/recipes/slave_spec.rb
+++ b/spec/unit/recipes/slave_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook Name:: mesos
 # Spec:: slave

--- a/test/integration/1-0-0/serverspec/mesos_version.rb
+++ b/test/integration/1-0-0/serverspec/mesos_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe command('mesos-master --version') do

--- a/test/integration/1-0-1/serverspec/mesos_version.rb
+++ b/test/integration/1-0-1/serverspec/mesos_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe command('mesos-master --version') do

--- a/test/integration/1-1-0/serverspec/mesos_version.rb
+++ b/test/integration/1-1-0/serverspec/mesos_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe command('mesos-master --version') do

--- a/test/integration/helpers/serverspec/mesos_install_spec.rb
+++ b/test/integration/helpers/serverspec/mesos_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 # verify packages

--- a/test/integration/helpers/serverspec/mesos_master_spec.rb
+++ b/test/integration/helpers/serverspec/mesos_master_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 # mesos master service

--- a/test/integration/helpers/serverspec/mesos_slave_spec.rb
+++ b/test/integration/helpers/serverspec/mesos_slave_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 # mesos slave service

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'serverspec'
 
 # Required by serverspec


### PR DESCRIPTION
This patch improves package management:
- it stop using dynamic version computation for rhel. This creates non-deterministc behavior
- it allows to pass options to package (convenient when using custom repositories for instance)

cc @criteo-cookbooks/sre-core 