### PR TITLE
Allow to choose mesos version to install

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,8 @@ default['java']['jdk_version'] = '8'
 default['mesos']['repo']       = true
 
 # Mesosphere Mesos version.
+# overriding this attribute to nil in a wrapper cookbook will force the
+# cookbook to use the latest version available in the repositories
 default['mesos']['version']    = '1.1.0'
 
 # Init system to use

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -38,11 +38,15 @@ when 'debian'
   end
 
   package 'mesos' do
-    action :install
     # --no-install-recommends to skip installing zk. unnecessary.
     options '--no-install-recommends'
-    # Glob is necessary to select the deb version string
-    version "#{node['mesos']['version']}*"
+    if node['mesos']['version']
+      action :install
+      # Glob is necessary to select the deb version string
+      version "#{node['mesos']['version']}*"
+    else
+      action :upgrade
+    end
   end
 when 'rhel'
   %w(unzip libcurl subversion).each do |pkg|
@@ -52,13 +56,11 @@ when 'rhel'
   end
 
   yum_package 'mesos' do
-    version lazy {
-      # get the version-release string directly from the Yum provider rpmdb
-      Chef::Provider::Package::Yum::YumCache
-        .instance.instance_variable_get('@rpmdb').lookup('mesos')
-        .find { |pkg| pkg.version.v == node['mesos']['version'] }
-        .version.to_s
-    }
+    if node['mesos']['version']
+      version node['mesos']['version']
+    else
+      action :upgrade
+    end
   end
 end
 


### PR DESCRIPTION
This patch allows to:
- select version to install on redhat
- allow to choose between strict version / always latest on
  debian&redhat

This is the combination of patches that lead to https://github.com/criteo-forks/mesos_cookbook/pull/3

Change-Id: Ibff3c22745eecac6e089145e17ce60241a683aa3